### PR TITLE
feat: Add LLM model selection dropdown

### DIFF
--- a/src/pokecounter_ai/handler.clj
+++ b/src/pokecounter_ai/handler.clj
@@ -14,8 +14,8 @@
 (defroutes app-routes
   (GET "/" [] (views/index-page))
 
-  (POST "/generate-counters" [pokemon-builds generation format]
-    (let [result (openai/generate-counters pokemon-builds generation format)]
+  (POST "/generate-counters" [pokemon-builds generation format llm-model]
+    (let [result (openai/generate-counters pokemon-builds generation format llm-model)]
       (if (:error result)
         (do
           (println "Error in handler:" (:error result))

--- a/src/pokecounter_ai/openai.clj
+++ b/src/pokecounter_ai/openai.clj
@@ -20,13 +20,16 @@
          "\nRespond ONLY with the Pokemon builds in Pokemon Showdown format, with no additional text or explanation."
          "\nExample format:\n\nScizor @ Heavy-Duty Boots\nAbility: Technician\nEVs: 252 Atk / 4 Def / 252 Spe\nJolly Nature\n- Bullet Punch\n- U-turn\n- Knock Off\n- Swords Dance")))
 
-(defn generate-counters [pokemon-builds generation format]
-  (let [api-key (System/getenv "OPENAI_API_KEY")]
+(defn generate-counters [pokemon-builds generation format llm-model]
+  (let [api-key (System/getenv "OPENAI_API_KEY")
+        selected-model (if (and llm-model (not (empty? llm-model)))
+                         llm-model
+                         "gpt-3.5-turbo")]
     (if (nil? api-key)
       {:error "OPENAI_API_KEY environment variable not set. Please export it before running the application."}
       (try
         (let [prompt (build-prompt pokemon-builds generation format)
-              request-body {:model "gpt-3.5-turbo"
+              request-body {:model selected-model
                            :messages [{:role "system"
                                       :content "You are a competitive Pokemon expert with deep knowledge of the metagame."}
                                      {:role "user"

--- a/src/pokecounter_ai/views.clj
+++ b/src/pokecounter_ai/views.clj
@@ -8,6 +8,10 @@
 (def pokemon-formats
   ["OU" "Ubers" "UU" "RU" "NU" "PU" "LC" "Monotype" "National Dex"])
 
+(def llm-models
+  [["GPT-3.5-Turbo" "gpt-3.5-turbo"]
+   ["GPT-4" "gpt-4"]])
+
 (defn layout [title & content]
   (html5
    [:head
@@ -44,6 +48,13 @@
                (form/drop-down {:class "form-select"}
                               "format"
                               pokemon-formats)]]
+
+             [:div.row.mb-3
+              [:div.col-md-6
+               [:label.form-label {:for "llm-model"} "LLM Model"]
+               (form/drop-down {:class "form-select"}
+                               "llm-model"
+                               llm-models)]]
 
              [:button.btn.btn-primary.mb-4 {:type "submit"} "Generate Counters"]]
 

--- a/test/pokecounter_ai/handler_test.clj
+++ b/test/pokecounter_ai/handler_test.clj
@@ -1,13 +1,61 @@
 (ns pokecounter-ai.handler-test
   (:require [clojure.test :refer [deftest is testing]]
             [ring.mock.request :as mock]
-            [pokecounter-ai.handler :refer [app]]))
+            [pokecounter-ai.handler :refer [app]]
+            [pokecounter-ai.openai :as openai]
+            [pokecounter-ai.views :as views]))
 
 (deftest test-app
   (testing "main route"
     (let [response (app (mock/request :get "/"))]
-      (is (= (:status response) 200))))
+      (is (= (:status response) 200))
+      (is (string? (:body response))) "Response body should be a string (HTML)"))
 
   (testing "not-found route"
     (let [response (app (mock/request :get "/invalid"))]
       (is (= (:status response) 404)))))
+
+(deftest generate-counters-route-test
+  (let [captured-args (atom nil)]
+    (with-redefs [openai/generate-counters (fn [& args]
+                                             (reset! captured-args args)
+                                             {:success true :result "Mocked AI Result"})
+                  views/results-page (fn [input results]
+                                       (str "Results page: " input " -> " results))
+                  views/error-page (fn [input error-message]
+                                     (str "Error page: " input " -> " error-message))]
+
+      (testing "POST /generate-counters with llm-model"
+        (let [form-params {"pokemon-builds" "Pikachu"
+                           "generation" "1"
+                           "format" "OU"
+                           "llm-model" "gpt-4-test"}
+              response (app (-> (mock/request :post "/generate-counters")
+                                (mock/body form-params) ; Compojure extracts from form-params, not body for POSTs with keywords
+                                (assoc :form-params form-params)))] ; Ensure form-params are correctly set for destructuring
+
+        (is (= 200 (:status response)) "Response status should be 200")
+        (is (some? @captured-args) "openai/generate-counters should have been called")
+        (is (= 4 (count @captured-args)) "openai/generate-counters should be called with 4 arguments")
+        (is (= "Pikachu" (nth @captured-args 0)) "First argument should be pokemon-builds")
+        (is (= "1" (nth @captured-args 1)) "Second argument should be generation")
+        (is (= "OU" (nth @captured-args 2)) "Third argument should be format")
+        (is (= "gpt-4-test" (nth @captured-args 3)) "Fourth argument should be llm-model"))
+
+      (testing "POST /generate-counters without llm-model (should pick default in openai ns)"
+        (reset! captured-args nil) ; Reset for next call
+        (let [form-params {"pokemon-builds" "Charmander"
+                           "generation" "2"
+                           "format" "UU"}
+              ; llm-model is intentionally omitted
+              response (app (-> (mock/request :post "/generate-counters")
+                                (mock/body form-params)
+                                (assoc :form-params form-params)))]
+
+        (is (= 200 (:status response)) "Response status should be 200")
+        (is (some? @captured-args) "openai/generate-counters should have been called")
+        (is (= 4 (count @captured-args)) "openai/generate-counters should be called with 4 arguments")
+        (is (= "Charmander" (nth @captured-args 0)))
+        (is (= "2" (nth @captured-args 1)))
+        (is (= "UU" (nth @captured-args 2)))
+        (is (nil? (nth @captured-args 3)) "Fourth argument (llm-model) should be nil if not provided"))))))

--- a/test/pokecounter_ai/openai_test.clj
+++ b/test/pokecounter_ai/openai_test.clj
@@ -1,0 +1,31 @@
+(ns pokecounter-ai.openai-test
+  (:require [clojure.test :refer :all]
+            [pokecounter-ai.openai :as openai]
+            [clj-http.client :as client]
+            [cheshire.core :as json]))
+
+(deftest generate-counters-test
+  (let [captured-request (atom nil)]
+    (with-redefs [System/getenv (fn [var-name]
+                                  (if (= var-name "OPENAI_API_KEY")
+                                    "test-api-key"
+                                    (System/getenv var-name)))
+                  client/post (fn [url req-options]
+                                (reset! captured-request (json/parse-string (:body req-options) true))
+                                {:status 200
+                                 :body {:choices [{:message {:content "Mocked response"}}]}})]
+
+      (testing "with a specified llm-model"
+        (openai/generate-counters "Pikachu" "1" "OU" "gpt-4")
+        (is (some? @captured-request) "Request was made")
+        (is (= "gpt-4" (:model @captured-request)) "Correct LLM model is used"))
+
+      (testing "with a nil llm-model"
+        (openai/generate-counters "Charmander" "1" "OU" nil)
+        (is (some? @captured-request) "Request was made")
+        (is (= "gpt-3.5-turbo" (:model @captured-request)) "Defaults to gpt-3.5-turbo for nil model"))
+
+      (testing "with an empty string llm-model"
+        (openai/generate-counters "Squirtle" "1" "OU" "")
+        (is (some? @captured-request) "Request was made")
+        (is (= "gpt-3.5-turbo" (:model @captured-request)) "Defaults to gpt-3.5-turbo for empty string model")))))


### PR DESCRIPTION
This feature introduces a dropdown menu on the main page, allowing you to select the Language Model (LLM) to be used for generating Pokemon counters.

Changes include:
- Modified `views.clj` to add the "LLM Model" dropdown in the form.
- Updated `handler.clj` to receive the `llm-model` parameter from the form and pass it to the OpenAI service.
- Enhanced `openai.clj` to use the provided `llm-model` in the API request to OpenAI, with a fallback to "gpt-3.5-turbo" if no model is specified or an empty string is passed.
- Added unit tests for `openai.clj` to verify the correct model parameter usage (including default fallback) by mocking the HTTP client.
- Added unit tests for `handler.clj` to ensure the `llm-model` parameter is correctly passed from the route to the OpenAI service function by mocking the service call.

The UI now presents options for "GPT-3.5-Turbo" and "GPT-4". The system gracefully handles API errors, which will be displayed to you. Manual testing confirmed the functionality.